### PR TITLE
fix : recurring event are not correctly displayed - EXO-74302

### DIFF
--- a/caldav-webapp/src/main/webapp/vue-app/caldav/caldav-connector/caldavConnector.js
+++ b/caldav-webapp/src/main/webapp/vue-app/caldav/caldav-connector/caldavConnector.js
@@ -89,23 +89,12 @@ export default {
           const startRangeDate = ICAL.Time.fromJSDate(caldavConnectorService.toDate(periodStartDate),false);//ICAL.Time
           const endRangeDate = ICAL.Time.fromJSDate(caldavConnectorService.toDate(periodEndDate),false);//ICAL.Time
 
-          //calculate the start of the range with the hour of the event
-          //without this, the expand will calculate ALL occurence even before the startRangeDate, which can lead to performance issues
-          //if the serie is very old
-          const startRangeDateForEventJSON = startRangeDate.toJSON();
-          startRangeDateForEventJSON.hour=vEvent.startDate.toJSON().hour;
-          startRangeDateForEventJSON.minute=vEvent.startDate.toJSON().minute;
-          startRangeDateForEventJSON.second=vEvent.startDate.toJSON().second;
-
-          const startRangeDateForEvent = new ICAL.Time(startRangeDateForEventJSON);
-
           const expand = new ICAL.RecurExpansion({
             component: eventComponent,
-            dtstart: startRangeDateForEvent
+            dtstart: vEvent.startDate
           });
           let next=expand.next(); //ICAL.Time
           while (next && next.compare(endRangeDate)<0) {
-            console.log('Next : ',next);
             if (next.compare(startRangeDate)>=0) {
               //create a new event for the recurrence :
               //we can have more than one occurence in the timerange requested


### PR DESCRIPTION
Before this fix, when a recurring event have a number of occurence (example 3 times), and start few weeks ago, the event is displayed in the current week, because the start of the expansion is set to startPeriodRange instead of startEventRange This commit ensure to use the correct start date