### PR TITLE
fix: avoid displaying remote events created from Agenda - EXO-85744

### DIFF
--- a/caldav-webapp/package-lock.json
+++ b/caldav-webapp/package-lock.json
@@ -12,7 +12,7 @@
         "buffer": "^6.0.3",
         "ical.js": "^1.5.0",
         "string_decoder": "^1.3.0",
-        "tsdav": "^2.0.7"
+        "tsdav": "^2.2.0"
       },
       "devDependencies": {
         "babel-loader": "^8.2.4",
@@ -1173,14 +1173,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1277,11 +1269,11 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2956,9 +2948,9 @@
       "dev": true
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -2984,25 +2976,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
     },
     "node_modules/node-releases": {
       "version": "2.0.5",
@@ -3840,23 +3813,17 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/tsdav": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/tsdav/-/tsdav-2.0.7.tgz",
-      "integrity": "sha512-KZ3BfjMCye6BBNIQ3YDtqmfE0qiuenne+HSMfsRSguqrUfDGyvz55qGAGz50hTV2A6A6SyraJzkQwVprDGElqw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tsdav/-/tsdav-2.2.1.tgz",
+      "integrity": "sha512-Vo8Ro0TgDfs6WNZ3ePx4rF+n46jUMjj1rJNx+QUjiys8K1n7ya5W/EfcUMHnfqG6TcKAwFNJnBKBhb2HB5Ns4w==",
       "dependencies": {
         "base-64": "1.0.0",
-        "cross-fetch": "4.0.0",
-        "debug": "4.3.4",
+        "debug": "4.4.3",
         "xml-js": "1.6.11"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/type-check": {
@@ -4089,11 +4056,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
     "node_modules/webpack": {
       "version": "5.76.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
@@ -4253,15 +4215,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -5280,14 +5233,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "requires": {
-        "node-fetch": "^2.6.12"
-      }
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -5358,11 +5303,11 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       }
     },
     "deep-equal": {
@@ -6578,9 +6523,9 @@
       "dev": true
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "nanoid": {
       "version": "3.3.4",
@@ -6600,14 +6545,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
     },
     "node-releases": {
       "version": "2.0.5",
@@ -7183,19 +7120,13 @@
         "is-number": "^7.0.0"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "tsdav": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/tsdav/-/tsdav-2.0.7.tgz",
-      "integrity": "sha512-KZ3BfjMCye6BBNIQ3YDtqmfE0qiuenne+HSMfsRSguqrUfDGyvz55qGAGz50hTV2A6A6SyraJzkQwVprDGElqw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tsdav/-/tsdav-2.2.1.tgz",
+      "integrity": "sha512-Vo8Ro0TgDfs6WNZ3ePx4rF+n46jUMjj1rJNx+QUjiys8K1n7ya5W/EfcUMHnfqG6TcKAwFNJnBKBhb2HB5Ns4w==",
       "requires": {
         "base-64": "1.0.0",
-        "cross-fetch": "4.0.0",
-        "debug": "4.3.4",
+        "debug": "4.4.3",
         "xml-js": "1.6.11"
       }
     },
@@ -7381,11 +7312,6 @@
         "graceful-fs": "^4.1.2"
       }
     },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
     "webpack": {
       "version": "5.76.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
@@ -7490,15 +7416,6 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
       "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
       "dev": true
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "which": {
       "version": "2.0.2",

--- a/caldav-webapp/package.json
+++ b/caldav-webapp/package.json
@@ -33,6 +33,6 @@
     "buffer": "^6.0.3",
     "ical.js": "^1.5.0",
     "string_decoder": "^1.3.0",
-    "tsdav": "^2.0.7"
+    "tsdav": "^2.2.0"
   }
 }

--- a/caldav-webapp/src/main/webapp/vue-app/caldav/caldav-connector/caldavConnector.js
+++ b/caldav-webapp/src/main/webapp/vue-app/caldav/caldav-connector/caldavConnector.js
@@ -41,7 +41,7 @@ export default {
     });
   },
   async getCalendar(clientCaldav){
-    const calendars = await clientCaldav.fetchCalendars({headersToExclude: 'If-None-Match'});
+    const calendars = await clientCaldav.fetchCalendars({headersToExclude: ['If-None-Match']});
     if (calendars.length === 0) {
       console.error('No calendar found');
       return null;
@@ -75,7 +75,7 @@ export default {
         start: start,
         end: end,
       },
-      headersToExclude: 'If-None-Match'
+      headersToExclude: ['If-None-Match']
     });
     const listEvent = [];
     events.map(event => {
@@ -196,7 +196,7 @@ export default {
           url: event.url,
           etag: event.etag,
         },
-        headersToExclude: 'If-None-Match'
+        headersToExclude: ['If-None-Match']
       });
     }
   },
@@ -219,8 +219,7 @@ export default {
       return Promise.all(null);
     }
     const isOccurrence = !!event.occurrence;
-    const parentEventId = isOccurrence ? event.parent.id : event.id; // L'UID doit être celui du parent pour les exceptions
-    const icalUID = parentEventId;
+    const icalUID = crypto.randomUUID();
     const filename = `${icalUID}.ics`;
 
     let start = toUTCString(event.start);
@@ -289,8 +288,9 @@ END:VCALENDAR
     iCalString = iCalString.trim();
     try {
       await clientCaldav.createCalendarObject({
-        calendar, iCalString, filename, headersToExclude: 'If-None-Match'
+        calendar, iCalString, filename, headersToExclude: ['If-None-Match']
       });
+      return {id: icalUID};
     } catch (e) {
       console.error('Error creating/updating CalDAV:', e, 'Contenu iCalString:', iCalString);
       throw e;


### PR DESCRIPTION
Remote events created with Caldav are not linked to the events created inside the Agenda application, because the instruction **clientCaldav.createCalendarObject** returns nothing. Thus the system can not created a remote event in database to link local and remote event
the fix generates a UID for the event that will be returned when the remote event is created.
Besides the tsdav library is upgraded 