### PR TITLE
fix: avoid creating new events on remote calendar after an event update - EXO-87878 (#22)

### DIFF
--- a/caldav-webapp/src/main/webapp/vue-app/caldav/caldav-connector/caldavConnector.js
+++ b/caldav-webapp/src/main/webapp/vue-app/caldav/caldav-connector/caldavConnector.js
@@ -241,7 +241,7 @@ export default {
       return Promise.all(null);
     }
     const isOccurrence = !!event.occurrence;
-    const icalUID = crypto.randomUUID();
+    const icalUID = isOccurrence ? event.parent.remoteId : event.remoteId || crypto.randomUUID();
     const filename = `${icalUID}.ics`;
 
     let start = toUTCString(event.start);


### PR DESCRIPTION

When an event gets updated, the vent is pushed to the remote calendar which creates a new event instead of updating the existing one. The fix checks if the event has already a remote calendar ID then it updates it, otherwise it assigns a new remote ID and creates a new event.